### PR TITLE
Use full npm module name in gatsby-config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Comes with built-in support for extracting menus defined in Markdown, but can al
 // gatsby-config.js
 plugins: [
   {
-    resolve: 'gatsby-plugins-menus',
+    resolve: '@stackbit/gatsby-plugins-menus',
     options: {
       // static definition of menu items (optional)
       menus: {

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ It is possible to override the default behavior of extracting menu items from Ma
 // gatsby-config.js
 plugins: [
   {
-    resolve: 'gatsby-plugins-menus',
+    resolve: '@stackbit/gatsby-plugins-menus',
     options: {
       ...
       // custom menu loading function (optional)


### PR DESCRIPTION
Ok I think this is all of them haha.