### PR TITLE
docs: fix menus syntax error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ plugins: [
               weight: 1
             }
           ]
-        ]
       },
       // Gatsby node types from which we extract menus (optional, see "Advanced usage")
       sourceNodeType: 'MarkdownRemark', 


### PR DESCRIPTION
There was an extra `]` in the `menus` option example in the README.